### PR TITLE
Add attributes for Mini Program Payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "description": "Abstract Puppet for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/schemas/mini-program.ts
+++ b/src/schemas/mini-program.ts
@@ -2,6 +2,8 @@ export interface MiniProgramPayload {
     appid?       : string,   // optional, appid, get from wechat (mp.weixin.qq.com)
     description? : string,   // optional, mini program title
     pagePath?    : string,   // optional, mini program page path
+    iconUrl?     : string,   // optional, mini program icon url
+    shareId?     : string,   // optional, the unique userId for who share this mini program
     thumbUrl?    : string,   // optional, default picture, convert to thumbnail
     title?       : string,   // optional, mini program title
     username?    : string,   // original ID, get from wechat (mp.weixin.qq.com)


### PR DESCRIPTION
Related issue: https://github.com/wechaty/wechaty-puppet-padplus/issues/226#issuecomment-628070373

`iconUrl` and `shareId` could be supported at `wechaty-puppet-donut`.

**shareId**
Unique user id for who share the mini program, but this id is not same as `wxid`.

> BTW, the whole `shareId` is looks like this : `0_${appid}_${userid}_${timestamp}_0`, there only need user to set the use id.

**iconUrl**
Support DIY icon by user, just set url link here.